### PR TITLE
Feature/duplicate translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Plugin::load('Duplicatable');
 This behavior provides *duplicate* method for the table. Argument is primary key to duplicate.
 Configuration options:
 * *contain* - set related entities that will be duplicated
+* *includeTranslations* - set true to duplicate translations
 * *remove* - fields that will be removed from the entity
 * *set* - fields that will be set to provided value
 * *prepend* - fields that will have value prepended by provided text
@@ -48,6 +49,8 @@ class InvoicesTable extends Table
         $this->addBehavior('Duplicatable.Duplicatable', [
             // duplicate also items and their properties
             'contain' => ['InvoiceItems.InvoiceItemProperties'],
+            // duplicate the translations if TranslateBehavior is loaded (also include related entities translations)
+            'includeTranslations' => true,
             // remove created field from both invoice and items
             'remove' => ['created', 'InvoiceItems.created'],
             // mark invoice as copied

--- a/tests/Fixture/I18nFixture.php
+++ b/tests/Fixture/I18nFixture.php
@@ -1,0 +1,70 @@
+<?php
+namespace Duplicatable\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * I18nFixture
+ *
+ */
+class I18nFixture extends TestFixture
+{
+
+    /**
+     * Table name
+     *
+     * @var string
+     */
+    public $table = 'i18n';
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'integer', 'length' => 11, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'autoIncrement' => true, 'precision' => null],
+        'locale' => ['type' => 'string', 'length' => 6, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'model' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'foreign_key' => ['type' => 'integer', 'length' => 10, 'unsigned' => false, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null, 'autoIncrement' => null],
+        'field' => ['type' => 'string', 'length' => 255, 'null' => false, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null, 'fixed' => null],
+        'content' => ['type' => 'text', 'length' => null, 'null' => true, 'default' => null, 'collate' => 'utf8_general_ci', 'comment' => '', 'precision' => null],
+        '_indexes' => [
+            'model' => ['type' => 'index', 'columns' => ['model', 'foreign_key', 'field'], 'length' => []],
+        ],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+            'locale' => ['type' => 'unique', 'columns' => ['locale', 'model', 'foreign_key', 'field'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => 1,
+            'locale' => 'es',
+            'model' => 'Invoices',
+            'foreign_key' => 1,
+            'field' => 'name',
+            'content' => 'Invoice name - es'
+        ],
+        [
+            'id' => 2,
+            'locale' => 'es',
+            'model' => 'InvoiceItemProperties',
+            'foreign_key' => 1,
+            'field' => 'name',
+            'content' => 'Property 1 - es'
+        ],
+    ];
+}


### PR DESCRIPTION
Add the config option 'includeTranslations', to also duplicate the entity translations if the model has TranslateBehavior loaded.

Works for related models too.
