### PR TITLE
Allows to set a callable for the `set` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configuration options:
 * *contain* - set related entities that will be duplicated
 * *includeTranslations* - set true to duplicate translations
 * *remove* - fields that will be removed from the entity
-* *set* - fields that will be set to provided value or callable to modify the value. If you provide a callable, it will take the current value as the only argument
+* *set* - fields that will be set to provided value or callable to modify the value. If you provide a callable, it will take the entity being cloned as the only argument
 * *prepend* - fields that will have value prepended by provided text
 * *append* - fields that will have value appended by provided text
 * *saveOptions* - options for save on primary table
@@ -55,8 +55,8 @@ class InvoicesTable extends Table
             'remove' => ['created', 'InvoiceItems.created'],
             // mark invoice as copied
             'set' => [
-                'name' => function($value) {
-                    return md5($value) . ' ' . $value;
+                'name' => function($entity) {
+                    return md5($entity->name) . ' ' . $entity->name;
                 },
                 'copied' => true
             ],

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Configuration options:
 * *contain* - set related entities that will be duplicated
 * *includeTranslations* - set true to duplicate translations
 * *remove* - fields that will be removed from the entity
-* *set* - fields that will be set to provided value
+* *set* - fields that will be set to provided value or callable to modify the value. If you provide a callable, it will take the current value as the only argument
 * *prepend* - fields that will have value prepended by provided text
 * *append* - fields that will have value appended by provided text
 * *saveOptions* - options for save on primary table
@@ -54,7 +54,12 @@ class InvoicesTable extends Table
             // remove created field from both invoice and items
             'remove' => ['created', 'InvoiceItems.created'],
             // mark invoice as copied
-            'set' => ['copied' => true],
+            'set' => [
+                'name' => function($value) {
+                    return md5($value) . ' ' . $value;
+                },
+                'copied' => true
+            ],
             // prepend properties name
             'prepend' => ['InvoiceItems.InvoiceItemProperties.name' => 'NEW '],
             // append copy to the name

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -134,7 +134,7 @@ class DuplicatableBehavior extends Behavior
 
                     if ($action == 'set') {
                         if (is_callable($value)) {
-                            $value = $value($entity->{$field});
+                            $value = $value($entity);
                         }
                     }
 

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -132,6 +132,12 @@ class DuplicatableBehavior extends Behavior
                         $value = $entity->{$field} . $value;
                     }
 
+                    if ($action == 'set') {
+                        if (is_callable($value)) {
+                            $value = $value($entity->{$field});
+                        }
+                    }
+
                     $entity->{$field} = $value;
                 }
             }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -114,13 +114,13 @@ class DuplicatableBehaviorTest extends TestCase
     {
         $this->Invoices->behaviors()->get('Duplicatable')->config([
             'set' => [
-                'name' => function($value) {
-                    return $value . ' ' . md5($value);
+                'name' => function($entity) {
+                    return $entity->name . ' ' . md5($entity->name);
                 }
             ]
         ]);
         $new = $this->Invoices->duplicate(1);
-        $invoice = $this->Invoices->get($new, ['contain' => ['InvoiceItems.InvoiceItemProperties', 'InvoiceItems.InvoiceItemVariations']]);
+        $invoice = $this->Invoices->get($new);
         $this->assertEquals('Invoice name 09ceae7acef129ed179da25bed1d8e5e - copy', $invoice->name);
 
         $this->Invoices->behaviors()->get('Duplicatable')->config([
@@ -136,10 +136,10 @@ class DuplicatableBehaviorTest extends TestCase
     /**
      * Modifier method to be used as a callable in the tests
      * 
-     * @param string $value Value to be set
+     * @param \Cake\Datasource\EntityInterface $entity Entity being cloned
      * @return string
      */
-    public function setModifier($value) {
-        return $value . ' ' . md5($value);
+    public function setModifier($entity) {
+        return $entity->name . ' ' . md5($entity->name);
     }
 }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -47,7 +47,7 @@ class DuplicatableBehaviorTest extends TestCase
     }
 
     /**
-     * Test duplicating
+     * Test duplicating with deeply nested associations
      *
      * @return void
      */
@@ -103,5 +103,43 @@ class DuplicatableBehaviorTest extends TestCase
 
         $this->assertEquals('NEW Property 1', $invoice->invoice_items[0]->invoice_item_properties[0]->name);
         $this->assertEquals('Property 1 - es', $invoice->invoice_items[0]->invoice_item_properties[0]->_translations['es']->name);
+    }
+
+    /**
+     * Test duplicating with the `set` param defined as a callable
+     *
+     * @return void
+     */
+    public function testDuplicateWithSetCallable()
+    {
+        $this->Invoices->behaviors()->get('Duplicatable')->config([
+            'set' => [
+                'name' => function($value) {
+                    return $value . ' ' . md5($value);
+                }
+            ]
+        ]);
+        $new = $this->Invoices->duplicate(1);
+        $invoice = $this->Invoices->get($new, ['contain' => ['InvoiceItems.InvoiceItemProperties', 'InvoiceItems.InvoiceItemVariations']]);
+        $this->assertEquals('Invoice name 09ceae7acef129ed179da25bed1d8e5e - copy', $invoice->name);
+
+        $this->Invoices->behaviors()->get('Duplicatable')->config([
+            'set' => [
+                'name' => [$this, 'setModifier']
+            ]
+        ]);
+        $new = $this->Invoices->duplicate(1);
+        $invoice = $this->Invoices->get($new);
+        $this->assertEquals('Invoice name 09ceae7acef129ed179da25bed1d8e5e - copy', $invoice->name);
+    }
+
+    /**
+     * Modifier method to be used as a callable in the tests
+     * 
+     * @param string $value Value to be set
+     * @return string
+     */
+    public function setModifier($value) {
+        return $value . ' ' . md5($value);
     }
 }


### PR DESCRIPTION
I found myself in a situation where I needed to do a bit of logic to set the value.
This gives the ability to use a callable as the `set` config option.
It takes only one argument : the current value of the field.