### PR TITLE
Enhancements

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -40,13 +40,17 @@ class DuplicatableBehavior extends Behavior
      * Duplicate record.
      *
      * @param int|string $id Id of entity to duplicate.
-     * @return int|string|bool Primary key value of new record or false on failure
+     * @return \Cake\Datasource\EntityInterface New entity or false on failure
      */
     public function duplicate($id)
     {
         $entity = $this->duplicateEntity($id);
+        $config = $this->config();
 
-        return $this->_table->save($entity, array_merge($this->config('saveOptions'), ['associated' => $this->config('contain')])) ? $entity->{$this->_table->primaryKey()} : false;
+        return $this->_table->save(
+            $entity,
+            $config['saveOptions'] + ['associated' => $config['contain']]
+        );
     }
 
     /**

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -184,12 +184,15 @@ class DuplicatableBehavior extends Behavior
         // modify related entities
         foreach ($this->config('contain') as $contain) {
             if (preg_match('/^' . preg_quote($pathPrefix, '/') . '([^.]+)/', $contain, $matches)) {
-                foreach ($entity->{Inflector::tableize($matches[1])} as $related) {
+                $assocName = $matches[1];
+                $propertyName = $table->{$assocName}->property();
+
+                foreach ($entity->{$propertyName} as $related) {
                     if ($related->isNew()) {
                         continue;
                     }
 
-                    $this->_modifyEntity($related, $table->{$matches[1]}, $pathPrefix . $matches[1] . '.');
+                    $this->_modifyEntity($related, $table->{$assocName}, $pathPrefix . $assocName . '.');
                 }
             }
         }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Duplicatable\Test\TestCase\Model\Behavior;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -58,8 +59,16 @@ class DuplicatableBehaviorTest extends TestCase
      */
     public function testDuplicate()
     {
-        $new = $this->Invoices->duplicate(1);
-        $invoice = $this->Invoices->get($new, ['contain' => ['InvoiceItems.InvoiceItemProperties', 'InvoiceItems.InvoiceItemVariations', 'Tags']]);
+        $result = $this->Invoices->duplicate(1);
+        $this->assertInstanceOf('Cake\Datasource\EntityInterface', $result);
+
+        $invoice = $this->Invoices->get($result->id, [
+            'contain' => [
+                'InvoiceItems.InvoiceItemProperties',
+                'InvoiceItems.InvoiceItemVariations',
+                'Tags'
+            ]
+        ]);
 
         // entity
         $this->assertEquals('Invoice name - copy', $invoice->name);
@@ -146,7 +155,7 @@ class DuplicatableBehaviorTest extends TestCase
         $this->Invoices->InvoiceItems->InvoiceItemProperties->addBehavior('Translate', ['fields' => ['name']]);
 
         $new = $this->Invoices->duplicate(1);
-        $invoice = $this->Invoices->get($new, [
+        $invoice = $this->Invoices->get($new->id, [
             'contain' => [
                 'InvoiceItems',
                 'InvoiceItems.InvoiceItemProperties' => function ($query) {
@@ -179,7 +188,7 @@ class DuplicatableBehaviorTest extends TestCase
             ]
         ]);
         $new = $this->Invoices->duplicate(1);
-        $invoice = $this->Invoices->get($new);
+        $invoice = $this->Invoices->get($new->id);
         $this->assertEquals('Invoice name 09ceae7acef129ed179da25bed1d8e5e - copy', $invoice->name);
 
         $this->Invoices->behaviors()->get('Duplicatable')->config([
@@ -188,7 +197,7 @@ class DuplicatableBehaviorTest extends TestCase
             ]
         ]);
         $new = $this->Invoices->duplicate(1);
-        $invoice = $this->Invoices->get($new);
+        $invoice = $this->Invoices->get($new->id);
         $this->assertEquals('Invoice name 09ceae7acef129ed179da25bed1d8e5e - copy', $invoice->name);
     }
 

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -77,18 +77,18 @@ class DuplicatableBehaviorTest extends TestCase
         $this->assertEquals(null, $invoice->created);
 
         // has many
-        $this->assertEquals('Item 1', $invoice->invoice_items[0]->name);
-        $this->assertEquals(null, $invoice->invoice_items[0]->created);
-        $this->assertEquals('Item 2', $invoice->invoice_items[1]->name);
-        $this->assertEquals(null, $invoice->invoice_items[1]->created);
+        $this->assertEquals('Item 1', $invoice->items[0]->name);
+        $this->assertEquals(null, $invoice->items[0]->created);
+        $this->assertEquals('Item 2', $invoice->items[1]->name);
+        $this->assertEquals(null, $invoice->items[1]->created);
 
         // double has many
-        $this->assertEquals('NEW Property 1', $invoice->invoice_items[0]->invoice_item_properties[0]->name);
-        $this->assertEquals('NEW Property 2', $invoice->invoice_items[0]->invoice_item_properties[1]->name);
-        $this->assertEquals('NEW Property 3', $invoice->invoice_items[1]->invoice_item_properties[0]->name);
-        $this->assertEquals('Variation 1', $invoice->invoice_items[0]->invoice_item_variations[0]->name);
-        $this->assertEquals('Variation 2', $invoice->invoice_items[1]->invoice_item_variations[0]->name);
-        $this->assertEquals('Variation 3', $invoice->invoice_items[1]->invoice_item_variations[1]->name);
+        $this->assertEquals('NEW Property 1', $invoice->items[0]->invoice_item_properties[0]->name);
+        $this->assertEquals('NEW Property 2', $invoice->items[0]->invoice_item_properties[1]->name);
+        $this->assertEquals('NEW Property 3', $invoice->items[1]->invoice_item_properties[0]->name);
+        $this->assertEquals('Variation 1', $invoice->items[0]->invoice_item_variations[0]->name);
+        $this->assertEquals('Variation 2', $invoice->items[1]->invoice_item_variations[0]->name);
+        $this->assertEquals('Variation 3', $invoice->items[1]->invoice_item_variations[1]->name);
 
         // belongs to
         $this->assertEquals(2, $invoice->invoice_type_id);
@@ -124,18 +124,18 @@ class DuplicatableBehaviorTest extends TestCase
         $this->assertEquals(1, $invoice->copied);
         $this->assertEquals(null, $invoice->created);
 
-        $this->assertEquals('Item 1', $invoice->invoice_items[0]->name);
-        $this->assertEquals(null, $invoice->invoice_items[0]->created);
-        $this->assertEquals('Item 2', $invoice->invoice_items[1]->name);
-        $this->assertEquals(null, $invoice->invoice_items[1]->created);
+        $this->assertEquals('Item 1', $invoice->items[0]->name);
+        $this->assertEquals(null, $invoice->items[0]->created);
+        $this->assertEquals('Item 2', $invoice->items[1]->name);
+        $this->assertEquals(null, $invoice->items[1]->created);
 
-        $this->assertEquals('NEW Property 1', $invoice->invoice_items[0]->invoice_item_properties[0]->name);
-        $this->assertEquals('NEW Property 2', $invoice->invoice_items[0]->invoice_item_properties[1]->name);
-        $this->assertEquals('NEW Property 3', $invoice->invoice_items[1]->invoice_item_properties[0]->name);
+        $this->assertEquals('NEW Property 1', $invoice->items[0]->invoice_item_properties[0]->name);
+        $this->assertEquals('NEW Property 2', $invoice->items[0]->invoice_item_properties[1]->name);
+        $this->assertEquals('NEW Property 3', $invoice->items[1]->invoice_item_properties[0]->name);
 
-        $this->assertEquals('Variation 1', $invoice->invoice_items[0]->invoice_item_variations[0]->name);
-        $this->assertEquals('Variation 2', $invoice->invoice_items[1]->invoice_item_variations[0]->name);
-        $this->assertEquals('Variation 3', $invoice->invoice_items[1]->invoice_item_variations[1]->name);
+        $this->assertEquals('Variation 1', $invoice->items[0]->invoice_item_variations[0]->name);
+        $this->assertEquals('Variation 2', $invoice->items[1]->invoice_item_variations[0]->name);
+        $this->assertEquals('Variation 3', $invoice->items[1]->invoice_item_variations[1]->name);
 
         $this->assertEquals(1, $invoice->tags[0]->id);
         $this->assertEquals('Tag 1', $invoice->tags[0]->name);
@@ -169,8 +169,8 @@ class DuplicatableBehaviorTest extends TestCase
         $this->assertEquals('Invoice name - copy', $invoice->name);
         $this->assertEquals('Invoice name - es', $invoice->_translations['es']->name);
 
-        $this->assertEquals('NEW Property 1', $invoice->invoice_items[0]->invoice_item_properties[0]->name);
-        $this->assertEquals('Property 1 - es', $invoice->invoice_items[0]->invoice_item_properties[0]->_translations['es']->name);
+        $this->assertEquals('NEW Property 1', $invoice->items[0]->invoice_item_properties[0]->name);
+        $this->assertEquals('Property 1 - es', $invoice->items[0]->invoice_item_properties[0]->_translations['es']->name);
     }
 
     /**

--- a/tests/test_app/TestApp/Model/Table/InvoicesTable.php
+++ b/tests/test_app/TestApp/Model/Table/InvoicesTable.php
@@ -33,7 +33,8 @@ class InvoicesTable extends Table
         $this->belongsTo('InvoiceTypes');
         $this->belongsToMany('Tags');
         $this->hasMany('InvoiceItems', [
-            'className' => 'TestApp\Model\Table\InvoiceItemsTable'
+            'className' => 'TestApp\Model\Table\InvoiceItemsTable',
+            'propertyName' => 'items'
         ]);
     }
 }


### PR DESCRIPTION
- Currently the related property name is guessed by simply inflecting the association name which failed when an association was configured to use custom property name. With this change the custom property name is now used properly.
- `duplicate()` now returns the new entity instead of just the primary key value. This brings it inline with return value of `save()`. Currently one has to do a new `find()` to fetch the newly created entity which is wasteful.
- Currently the second argument of `_modifyEntity()` is named as `$table` but typhinted as `Association` which was confusing. Moreover if the argument was null it got set to a `Table` instance internally which was not ideal. So to make code easier to follow I removed the type hint, changed arg name to `$object` and removed default null.

Since the return value of `duplicate()` has changed you might want to bump the major release version if you are following strict semver.