### PR TITLE
fixes non-unique column id SQL error

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -70,7 +70,7 @@ class DuplicatableBehavior extends Behavior
             $query = $query->contain($contain);
         }
 
-        $entity = $query->where(['id' => $id])->firstOrFail();
+        $entity = $query->where([$this->_table->alias() . '.id' => $id])->firstOrFail();
 
         // process entity
         foreach ($this->config('contain') as $contain) {

--- a/tests/test_app/TestApp/Model/Table/InvoicesTable.php
+++ b/tests/test_app/TestApp/Model/Table/InvoicesTable.php
@@ -13,6 +13,7 @@ class InvoicesTable extends Table
             'contain' => [
                 'InvoiceItems.InvoiceItemProperties',
                 'InvoiceItems.InvoiceItemVariations',
+                'InvoiceTypes',
                 'Tags'
             ],
             'remove' => [


### PR DESCRIPTION
This error only occurs, when a belongsTo association is included into the contained tables.

This is the error message I get when the alias is set in the where clause: "Error: SQLSTATE[23000]: Integrity constraint violation: 1052 Column 'id' in where clause is ambiguous"

I had to modify your test-case a little bit and include the InvoiceTypes into the contain, to reproduce this error.