### PR TITLE
hasOne accociations

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -215,13 +215,19 @@ class DuplicatableBehavior extends Behavior
         $assocName = array_shift($parts);
         $prop = $object->{$assocName}->property();
 
-        foreach ($entity->{$prop} as $e) {
-            if (!empty($parts)) {
-                $this->_drillDownAssoc($e, $object->{$assocName}, $parts);
+        if (!is_array($entity->{$prop})) {
+            if (!$entity->{$prop}->isNew()) {
+                $this->_modifyEntity($entity->{$prop}, $object->{$assocName});
             }
+        } else {
+            foreach ($entity->{$prop} as $e) {
+                if (!empty($parts)) {
+                    $this->_drillDownAssoc($e, $object->{$assocName}, $parts);
+                }
 
-            if (!$e->isNew()) {
-                $this->_modifyEntity($e, $object->{$assocName});
+                if (!$e->isNew()) {
+                    $this->_modifyEntity($e, $object->{$assocName});
+                }
             }
         }
     }

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -216,6 +216,11 @@ class DuplicatableBehavior extends Behavior
         $prop = $object->{$assocName}->property();
 
         if (!is_array($entity->{$prop})) {
+
+            if (!empty($parts)) {
+                $this->_drillDownAssoc($entity->{$prop}, $object->{$assocName}, $parts);
+            }
+
             if (!$entity->{$prop}->isNew()) {
                 $this->_modifyEntity($entity->{$prop}, $object->{$assocName});
             }


### PR DESCRIPTION
When I use duplicateEntity on an entity with a hasOne association, it does not unset the primary and foreign keys.  I think this is because the drillDownAssoc assumes the property is an array and can run through a foreach loop.

When it is a hasOne, it skips the foreach, so _modifyEntity is never called.