### PR TITLE
Skip associatons if origin entities are empty

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -231,6 +231,9 @@ class DuplicatableBehavior extends Behavior
             return;
         }
 
+        if(empty($associated))
+            return;
+        
         foreach ($associated as $e) {
             if (!empty($parts)) {
                 $this->_drillDownAssoc($e, $object->{$assocName}, $parts);

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -215,7 +215,7 @@ class DuplicatableBehavior extends Behavior
         $prop = $object->{$assocName}->property();
         $associated = $entity->{$prop};
 
-        if ($object->{$assocName} instanceof BelongsTo) {
+        if (empty($associated) || $object->{$assocName} instanceof BelongsTo) {
             return;
         }
 
@@ -230,9 +230,6 @@ class DuplicatableBehavior extends Behavior
 
             return;
         }
-
-        if(empty($associated))
-            return;
         
         foreach ($associated as $e) {
             if (!empty($parts)) {

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -230,7 +230,7 @@ class DuplicatableBehavior extends Behavior
 
             return;
         }
-        
+
         foreach ($associated as $e) {
             if (!empty($parts)) {
                 $this->_drillDownAssoc($e, $object->{$assocName}, $parts);


### PR DESCRIPTION
Behavior should work also if associated entities are empty, right now it warns 
<b>Warning</b> (2)</a>: Invalid argument supplied for foreach()