### PR TITLE
Prepare the plugin for CakePHP 3.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: php
 
 php:
-  - 7.0
-  - 5.5
   - 5.6
+  - 7.0
   - 7.1
+  - 7.2
 
 dist: trusty
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4.16",
-        "cakephp/orm": "~3.0"
+        "php": ">=5.6.0",
+        "cakephp/orm": "3.6.0-beta1"
     },
     "require-dev": {
         "phpunit/phpunit": "<6.0",
-        "cakephp/cakephp": "~3.0"
+        "cakephp/cakephp": "3.6.0-beta1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -48,7 +48,7 @@ class DuplicatableBehavior extends Behavior
      */
     public function duplicate($id)
     {
-        return $this->_table->save($this->duplicateEntity($id), $this->config('saveOptions') + ['associated' => $this->config('contain')]);
+        return $this->_table->save($this->duplicateEntity($id), $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain')]);
     }
 
     /**
@@ -70,23 +70,23 @@ class DuplicatableBehavior extends Behavior
             $query = $query->contain($contain);
         }
 
-        $entity = $query->where([$this->_table->alias() . '.id' => $id])->firstOrFail();
+        $entity = $query->where([$this->_table->getAlias() . '.id' => $id])->firstOrFail();
 
         // process entity
-        foreach ($this->config('contain') as $contain) {
+        foreach ($this->getConfig('contain') as $contain) {
             $parts = explode('.', $contain);
             $this->_drillDownAssoc($entity, $this->_table, $parts);
         }
 
         $this->_modifyEntity($entity, $this->_table);
 
-        foreach ($this->config('remove') as $field) {
+        foreach ($this->getConfig('remove') as $field) {
             $parts = explode('.', $field);
             $this->_drillDownEntity('remove', $entity, $parts);
         }
 
         foreach (['set', 'prepend', 'append'] as $action) {
-            foreach ($this->config($action) as $field => $value) {
+            foreach ($this->getConfig($action) as $field => $value) {
                 $parts = explode('.', $field);
                 $this->_drillDownEntity($action, $entity, $parts, $value);
             }
@@ -103,14 +103,14 @@ class DuplicatableBehavior extends Behavior
      */
     protected function _getFinder($assocPath = null)
     {
-        $finders = $this->config('finder');
+        $finders = $this->getConfig('finder');
 
         if (!is_array($finders)) {
             $finders = [$finders];
         }
 
         // for backward compatibility
-        if ($this->config('includeTranslations')) {
+        if ($this->getConfig('includeTranslations')) {
             $finders[] = 'translations';
         }
 
@@ -150,7 +150,7 @@ class DuplicatableBehavior extends Behavior
     protected function _getContain()
     {
         $contain = [];
-        foreach ($this->config('contain') as $assocPath) {
+        foreach ($this->getConfig('contain') as $assocPath) {
             $finders = $this->_getFinder($assocPath);
             if ($finders === ['all']) {
                 $contain[] = $assocPath;
@@ -182,11 +182,11 @@ class DuplicatableBehavior extends Behavior
             unset($entity->_joinData);
         } else {
             // unset primary key
-            unset($entity->{$object->primaryKey()});
+            unset($entity->{$object->getPrimaryKey()});
 
             // unset foreign key
             if ($object instanceof Association) {
-                unset($entity->{$object->foreignKey()});
+                unset($entity->{$object->getPrimaryKey()});
             }
         }
 
@@ -212,7 +212,7 @@ class DuplicatableBehavior extends Behavior
     protected function _drillDownAssoc(EntityInterface $entity, $object, array $parts)
     {
         $assocName = array_shift($parts);
-        $prop = $object->{$assocName}->property();
+        $prop = $object->{$assocName}->getProperty();
         $associated = $entity->{$prop};
 
         if (empty($associated) || $object->{$assocName} instanceof BelongsTo) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,7 +52,7 @@ Configure::write('Session', [
     'defaults' => 'php'
 ]);
 
-Cache::config([
+Cache::setConfig([
     '_cake_core_' => [
         'engine' => 'File',
         'prefix' => 'cake_core_',
@@ -76,7 +76,7 @@ if (!getenv('db_class')) {
     putenv('db_dsn=sqlite::memory:');
 }
 
-ConnectionManager::config('test', [
+ConnectionManager::setConfig('test', [
     'className' => 'Cake\Database\Connection',
     'driver' => getenv('db_class'),
     'dsn' => getenv('db_dsn'),
@@ -86,7 +86,7 @@ ConnectionManager::config('test', [
     'timezone' => 'UTC'
 ]);
 
-Log::config([
+Log::setConfig([
     'debug' => [
         'engine' => 'Cake\Log\Engine\FileLog',
         'levels' => ['notice', 'info', 'debug'],


### PR DESCRIPTION
I'm making heavy use of this plugin in an app I'm migrating from 3.3 to 3.6.
However, in 3.6.0, there was a lot of deprecation warnings added.

This PR aims to prepare the plugin for 3.6.0. It is currently in beta right now, so it might be good to create a new branch until the release is official and flagged stable.
I've done it with other plugin maintainer already.

As beta releases are done, I'll update the hard dependency to CakePHP until it is released.