### PR TITLE
Lower CakePHP requirement to 3.5+.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,14 @@ matrix:
     - php: 7.0
       env: PHPCS=1 DEFAULT=0
 
+    - php: 5.6
+      env: PREFER_LOWEST=1
+
 before_script:
   - if [[ $TRAVIS_PHP_VERSION != 7.0 ]]; then phpenv config-rm xdebug.ini; fi
 
-  - composer install --prefer-dist --no-interaction
+  - if [[ $PREFER_LOWEST != 1 ]]; then composer update --no-interaction; fi
+  - if [[ $PREFER_LOWEST == 1 ]]; then composer update --no-interaction --prefer-lowest --prefer-stable; fi
 
   - sh -c "if [ '$PHPCS' = '1' ]; then composer require cakephp/cakephp-codesniffer; fi"
 

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,11 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
-        "cakephp/orm": "3.6.0-beta1"
+        "cakephp/orm": "^3.5"
     },
     "require-dev": {
-        "phpunit/phpunit": "<6.0",
-        "cakephp/cakephp": "3.6.0-beta1"
+        "phpunit/phpunit": "^5.7.14|^6.0",
+        "cakephp/cakephp": "^3.5"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Jumping to CakePHP 3.6 is not necessary. I have added new travis build to ensure the code works on 3.5 and 3.6.