### PR TITLE
Fixes #33 error when primary key is not id

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -68,7 +68,7 @@ class DuplicatableBehavior extends Behavior
             $query = $query->contain($contain);
         }
 
-        $entity = $query->where([$this->_table->getAlias() . '.id' => $id])->firstOrFail();
+        $entity = $query->where([$this->_table->getAlias() . '.' . $this->_table->getPrimaryKey() => $id])->firstOrFail();
 
         // process entity
         foreach ($this->getConfig('contain') as $contain) {


### PR DESCRIPTION
I'm converting a CakePHP 2.x app to CakePHP 3.x app and found this plugin useful - thanks. 

I came across this issue because the database table primary keys are not all "id"s