### PR TITLE
Fixed a bug with string setters being executed as callables

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -292,7 +292,7 @@ class DuplicatableBehavior extends Behavior
                 break;
 
             case 'set':
-                if (is_callable($value)) {
+                if (is_callable($value) && !is_string($value)) {
                     $value = $value($entity);
                 }
                 $entity->set($prop, $value);

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -292,7 +292,7 @@ class DuplicatableBehavior extends Behavior
                 break;
 
             case 'set':
-                if (is_callable($value) && !is_string($value)) {
+                if (!is_string($value) && is_callable($value)) {
                     $value = $value($entity);
                 }
                 $entity->set($prop, $value);

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Duplicatable\Test\TestCase\Model\Behavior;
 
+use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -179,5 +180,26 @@ class DuplicatableBehaviorTest extends TestCase
             ])
             ->all();
         $this->assertEquals(2, $records->count());
+    }
+
+    public function testDuplicateWithSetters()
+    {
+        $this->Invoices->removeBehavior('Duplicatable');
+        $this->Invoices->addBehavior('Duplicatable.Duplicatable', [
+            'set' => [
+                'copied' => true,
+                'name' => 'Example Invoice - copy',
+                'contact_name' => function (EntityInterface $entity) {
+                    return strrev($entity->get('contact_name'));
+                }
+            ]
+        ]);
+
+        $result = $this->Invoices->duplicate(1);
+        $invoice = $this->Invoices->get($result->id);
+
+        $this->assertEquals('Example Invoice - copy', $invoice->name);
+        $this->assertEquals('eman tcatnoC', $invoice->contact_name);
+        $this->assertEquals(1, $invoice->copied);
     }
 }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -188,7 +188,7 @@ class DuplicatableBehaviorTest extends TestCase
         $this->Invoices->addBehavior('Duplicatable.Duplicatable', [
             'set' => [
                 'copied' => true,
-                'name' => 'Example Invoice - copy',
+                'name' => 'mail',
                 'contact_name' => function (EntityInterface $entity) {
                     return strrev($entity->get('contact_name'));
                 }
@@ -198,7 +198,7 @@ class DuplicatableBehaviorTest extends TestCase
         $result = $this->Invoices->duplicate(1);
         $invoice = $this->Invoices->get($result->id);
 
-        $this->assertEquals('Example Invoice - copy', $invoice->name);
+        $this->assertEquals('mail', $invoice->name);
         $this->assertEquals('eman tcatnoC', $invoice->contact_name);
         $this->assertEquals(1, $invoice->copied);
     }


### PR DESCRIPTION
This bug fixes an issue with the behaviour which arises if a setter is used and a string is passed which matches a PHP function name. The function is then executed as a callable and unknown side effects are created.

I have fixed this bug and also included a new test-case to cover the regression.

/cc @ogrrd