### PR TITLE
Fixed a regression with the preserveJoinData option

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -178,9 +178,9 @@ class DuplicatableBehavior extends Behavior
     protected function _modifyEntity(EntityInterface $entity, $object)
     {
         // belongs to many is tricky
-        if ($object instanceof BelongsToMany && ! $this->getConfig('preserveJoinData')) {
+        if ($object instanceof BelongsToMany && !$this->getConfig('preserveJoinData')) {
             unset($entity->_joinData);
-        } else {
+        } else if (!$object instanceof BelongsToMany) {
             // unset primary key
             unset($entity->{$object->getPrimaryKey()});
 

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -180,7 +180,7 @@ class DuplicatableBehavior extends Behavior
         // belongs to many is tricky
         if ($object instanceof BelongsToMany && !$this->getConfig('preserveJoinData')) {
             unset($entity->_joinData);
-        } else if (!$object instanceof BelongsToMany) {
+        } elseif (!$object instanceof BelongsToMany) {
             // unset primary key
             unset($entity->{$object->getPrimaryKey()});
 

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -213,28 +213,20 @@ class DuplicatableBehaviorTest extends TestCase
             'contain' => [
                 'Tags',
             ],
-            'preserveJoinData' => false,
-        ]);
-
-        $duplicated = $this->Invoices->duplicateEntity(1);
-
-        $this->assertEquals(false, isset($duplicated->tags[0]->_joinData));
-        $this->assertEquals(false, isset($duplicated->tags[1]->_joinData));
-
-        $this->Invoices->removeBehavior('Duplicatable');
-
-        $this->Invoices->addBehavior('Duplicatable.Duplicatable', [
-            'contain' => [
-                'Tags',
-            ],
             'preserveJoinData' => true,
         ]);
 
-        $duplicated = $this->Invoices->duplicateEntity(1);
+        $result = $this->Invoices->duplicate(1);
+        $invoice = $this->Invoices->get($result->id, [
+            'contain' => [
+                'Tags',
+            ]
+        ]);
 
-        $this->assertEquals(true, isset($duplicated->tags[0]->_joinData));
-        $this->assertEquals(true, isset($duplicated->tags[1]->_joinData));
-        $this->assertEquals(true, $duplicated->tags[0]->_joinData->is_preserved);
-        $this->assertEquals(true, $duplicated->tags[1]->_joinData->is_preserved);
+        $this->assertEquals(true, $invoice->tags[0]->_joinData->is_preserved);
+        $this->assertEquals(true, $invoice->tags[1]->_joinData->is_preserved);
+
+        // check that tags are not duplicated
+        $this->assertEquals(2, $this->Invoices->Tags->find()->count());
     }
 }


### PR DESCRIPTION
Hey!

This very simple pull request fixes a regression introduced by #42.

The original intent of the `_modifyEntity` method is to enter the `if` when `$object` is an instance of `BelongsToMany` and the `else` if not.

Now, when activating the `preserveJoinData` option, the `if` part is skipped correctly, but we enter the `else` part even if `$object` is an instance of `BelongsToMany`, which clears primary keys and causes duplicates of related entities in the database.

With this pull request, we check if `$object` is not an instance of `BelongsToMany` before clearing primary keys.