### PR TITLE
Resolves #44 - Cope with removing properties from entities which might be null

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -266,7 +266,7 @@ class DuplicatableBehavior extends Behavior
             return;
         }
 
-        if (is_iterable($entity->{$prop})) {
+        if ($entity->{$prop} !== null) {
             foreach ($entity->{$prop} as $key => $e) {
                 $this->_drillDownEntity($action, $e, $parts, $value);
             }

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -267,7 +267,7 @@ class DuplicatableBehavior extends Behavior
         }
 
         if (is_array($entity->{$prop}) || $entity->{$prop} instanceof \Traversable) {
-            foreach ($entity->{$prop} as $key => $e) {
+            foreach ($entity->{$prop} as $e) {
                 $this->_drillDownEntity($action, $e, $parts, $value);
             }
         }

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -266,7 +266,7 @@ class DuplicatableBehavior extends Behavior
             return;
         }
 
-        if (is_iterable($entity->{$prop})) {
+        if (is_array($entity->{$prop}) || $entity->{$prop} instanceof \Traversable) {
             foreach ($entity->{$prop} as $key => $e) {
                 $this->_drillDownEntity($action, $e, $parts, $value);
             }

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -266,7 +266,7 @@ class DuplicatableBehavior extends Behavior
             return;
         }
 
-        if ($entity->{$prop} !== null) {
+        if (is_iterable($entity->{$prop})) {
             foreach ($entity->{$prop} as $key => $e) {
                 $this->_drillDownEntity($action, $e, $parts, $value);
             }

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -266,8 +266,10 @@ class DuplicatableBehavior extends Behavior
             return;
         }
 
-        foreach ($entity->{$prop} as $key => $e) {
-            $this->_drillDownEntity($action, $e, $parts, $value);
+        if (is_iterable($entity->{$prop})) {
+            foreach ($entity->{$prop} as $key => $e) {
+                $this->_drillDownEntity($action, $e, $parts, $value);
+            }
         }
     }
 

--- a/tests/Fixture/InvoicesFixture.php
+++ b/tests/Fixture/InvoicesFixture.php
@@ -33,6 +33,14 @@ class InvoicesFixture extends TestFixture
             'contact_name' => 'Contact name 2',
             'copied' => 0,
             'created' => '2015-05-17 03:20:54'
-        ]
+        ],
+        [
+            'id' => 3,
+            'invoice_type_id' => 1,
+            'name' => 'Invoice with removed optionally null associations',
+            'contact_name' => 'Contact name 3',
+            'copied' => 0,
+            'created' => '2015-05-17 03:20:54'
+        ],
     ];
 }

--- a/tests/Fixture/InvoicesFixture.php
+++ b/tests/Fixture/InvoicesFixture.php
@@ -32,7 +32,7 @@ class InvoicesFixture extends TestFixture
             'name' => 'Invoice name 2',
             'contact_name' => 'Contact name 2',
             'copied' => 0,
-            'created' => '2015-05-17 03:20:54'
+            'created' => '2015-05-17 03:20:54',
         ],
         [
             'id' => 3,
@@ -40,7 +40,7 @@ class InvoicesFixture extends TestFixture
             'name' => 'Invoice with removed optionally null associations',
             'contact_name' => 'Contact name 3',
             'copied' => 0,
-            'created' => '2015-05-17 03:20:54'
+            'created' => '2015-05-17 03:20:54',
         ],
     ];
 }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -7,6 +7,8 @@ use Cake\TestSuite\TestCase;
 
 /**
  * DuplicatableBehavior Test Case
+ *
+ * @property \TestApp\Model\Table\InvoicesTable $Invoices
  */
 class DuplicatableBehaviorTest extends TestCase
 {
@@ -80,7 +82,6 @@ class DuplicatableBehaviorTest extends TestCase
 
         // has one
         $this->assertEquals(3, $invoice->invoice_data->id);
-        $this->assertEquals($result->id, $invoice->invoice_data->id);
         $this->assertEquals('Data for invoice 1 - copy', $invoice->invoice_data->data);
 
         // has many
@@ -228,5 +229,21 @@ class DuplicatableBehaviorTest extends TestCase
 
         // check that tags are not duplicated
         $this->assertEquals(2, $this->Invoices->Tags->find()->count());
+    }
+
+    /**
+     * Test that an entity with optionally null association can have fields removed when being duplicated
+     *
+     * @return void
+     */
+    public function testDuplicateWithRemoveOnNullAssociations()
+    {
+        $this->Invoices->behaviors()->get('Duplicatable')->setConfig('remove', ['invoice_data.data']);
+
+        $result = $this->Invoices->duplicate(3);
+        $this->assertInstanceOf('Cake\Datasource\EntityInterface', $result);
+
+        $this->assertNotEquals(3, $result->get('id'));
+        $this->assertEmpty($result->get('invoice_data'));
     }
 }

--- a/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/DuplicatableBehaviorTest.php
@@ -241,7 +241,7 @@ class DuplicatableBehaviorTest extends TestCase
         $this->Invoices->behaviors()->get('Duplicatable')->setConfig('remove', ['invoice_data.data']);
 
         $result = $this->Invoices->duplicate(3);
-        $this->assertInstanceOf('Cake\Datasource\EntityInterface', $result);
+        $this->assertInstanceOf(EntityInterface::class, $result);
 
         $this->assertNotEquals(3, $result->get('id'));
         $this->assertEmpty($result->get('invoice_data'));


### PR DESCRIPTION
Added a test case and a fix for duplicating entities with removing a property when the association might be null.

By checking if the entity is null before trying to action the property, this prevents an exception in the foreach.

I have added a fixture for testing this use-case, which meant I had to change an existing test assertion, as it was asserting that the auto-incrementing id's would match, which is no longer possible with a third invoice. Hope this is okay.

I also took the liberty of adding an `@property` tag to the test-case for ease of auto-completion.