### PR TITLE
saveOptions contains "duplicated" and "originalId"

### DIFF
--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -53,7 +53,7 @@ class DuplicatableBehavior extends Behavior
     {
         return $this->_table->save(
             $this->duplicateEntity($id),
-            $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain')]
+            $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain'), 'duplicated' => true, 'originalId' => $id]
         );
     }
 

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -47,13 +47,14 @@ class DuplicatableBehavior extends Behavior
      * Duplicate record.
      *
      * @param string|int $id Id of entity to duplicate.
+     * @param array $saveOptions Additional save options to pass to save().
      * @return \Cake\Datasource\EntityInterface|false New entity or false on failure
      */
-    public function duplicate(int|string $id): EntityInterface|false
+    public function duplicate(int|string $id, array $saveOptions = []): EntityInterface|false
     {
         return $this->_table->save(
             $this->duplicateEntity($id),
-            $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain'), 'duplicated' => true, 'originalId' => $id, 'duplicatedModel' => $this->_table->getAlias()]
+            $this->getConfig('saveOptions') + $saveOptions + ['associated' => $this->getConfig('contain'), 'duplicated' => true, 'originalId' => $id, 'duplicatedModel' => $this->_table->getAlias()]
         );
     }
 

--- a/src/Model/Behavior/DuplicatableBehavior.php
+++ b/src/Model/Behavior/DuplicatableBehavior.php
@@ -53,7 +53,7 @@ class DuplicatableBehavior extends Behavior
     {
         return $this->_table->save(
             $this->duplicateEntity($id),
-            $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain'), 'duplicated' => true, 'originalId' => $id]
+            $this->getConfig('saveOptions') + ['associated' => $this->getConfig('contain'), 'duplicated' => true, 'originalId' => $id, 'duplicatedModel' => $this->_table->getAlias()]
         );
     }
 


### PR DESCRIPTION
This DuplicatableBehavior has been very useful in many projects!

However, I had a use case where I needed to handle things differently if the Entity had been saved as normal, or if it had been duplicated. The changes in this pull request pass two parameters to the saveOptions, indicating that the Entity had been duplicated, and also what the originalId was.